### PR TITLE
Tighten nsp

### DIFF
--- a/fpo-api/openshift/templates/django/django-deploy.yaml
+++ b/fpo-api/openshift/templates/django/django-deploy.yaml
@@ -41,9 +41,16 @@ objects:
         Allow the application's API to talk to either the database or pdf microservice.
       source:
         - - role=${ROLE}
+          - app: ${APP_NAME}
+          - env: ${TAG_NAME}
+
       destination:
         - - role=db
+          - app: ${APP_NAME}
+          - env: ${TAG_NAME}
         - - role=pdf
+          - app: ${APP_NAME}
+          - env: ${TAG_NAME}
 
   - kind: Service
     apiVersion: v1

--- a/fpo-api/openshift/templates/django/django-deploy.yaml
+++ b/fpo-api/openshift/templates/django/django-deploy.yaml
@@ -109,6 +109,8 @@ objects:
             role: ${ROLE}
             env: ${TAG_NAME}
         spec:
+          nodeSelector:
+            aporeto-enforcerd: 'true'
           containers:
             - name: ${NAME}
               image: " "

--- a/fpo-api/openshift/templates/django/django-deploy.yaml
+++ b/fpo-api/openshift/templates/django/django-deploy.yaml
@@ -41,16 +41,16 @@ objects:
         Allow the application's API to talk to either the database or pdf microservice.
       source:
         - - role=${ROLE}
-          - app: ${APP_NAME}
-          - env: ${TAG_NAME}
+          - app=${APP_NAME}
+          - env=${TAG_NAME}
 
       destination:
         - - role=db
-          - app: ${APP_NAME}
-          - env: ${TAG_NAME}
+          - app=${APP_NAME}
+          - env=${TAG_NAME}
         - - role=pdf
-          - app: ${APP_NAME}
-          - env: ${TAG_NAME}
+          - app=${APP_NAME}
+          - env=${TAG_NAME}
 
   - kind: Service
     apiVersion: v1

--- a/fpo-api/openshift/templates/schema-spy/schema-spy-deploy.yaml
+++ b/fpo-api/openshift/templates/schema-spy/schema-spy-deploy.yaml
@@ -22,8 +22,12 @@ objects:
       source:
       source:
         - - role=${ROLE}
+          - app: ${APP_NAME}
+          - env: ${TAG_NAME}
       destination:
         - - role=db
+          - app: ${APP_NAME}
+          - env: ${TAG_NAME}
 
   - kind: Service
     apiVersion: v1

--- a/fpo-api/openshift/templates/schema-spy/schema-spy-deploy.yaml
+++ b/fpo-api/openshift/templates/schema-spy/schema-spy-deploy.yaml
@@ -22,12 +22,12 @@ objects:
       source:
       source:
         - - role=${ROLE}
-          - app: ${APP_NAME}
-          - env: ${TAG_NAME}
+          - app=${APP_NAME}
+          - env=${TAG_NAME}
       destination:
         - - role=db
-          - app: ${APP_NAME}
-          - env: ${TAG_NAME}
+          - app=${APP_NAME}
+          - env=${TAG_NAME}
 
   - kind: Service
     apiVersion: v1

--- a/fpo-api/openshift/templates/schema-spy/schema-spy-deploy.yaml
+++ b/fpo-api/openshift/templates/schema-spy/schema-spy-deploy.yaml
@@ -110,6 +110,8 @@ objects:
             role: ${ROLE}
             env: ${TAG_NAME}
         spec:
+          nodeSelector:
+            aporeto-enforcerd: 'true'
           containers:
           - name: ${NAME}
             image: " "

--- a/fpo-db/openshift/templates/postgresql-deploy.yaml
+++ b/fpo-db/openshift/templates/postgresql-deploy.yaml
@@ -48,6 +48,8 @@ objects:
             role: ${ROLE}
             env: ${TAG_NAME}
         spec:
+          nodeSelector:
+            aporeto-enforcerd: 'true'
           volumes:
             - name: "${NAME}-data"
               persistentVolumeClaim:

--- a/fpo-pdf/openshift/templates/weasyprint-deploy.yaml
+++ b/fpo-pdf/openshift/templates/weasyprint-deploy.yaml
@@ -60,6 +60,8 @@ objects:
             role: ${ROLE}
             env: ${TAG_NAME}
         spec:
+          nodeSelector:
+            aporeto-enforcerd: 'true'
           containers:
             - name: ${NAME}
               image: " "

--- a/fpo-web/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.yaml
+++ b/fpo-web/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.yaml
@@ -57,6 +57,8 @@ objects:
             role: ${ROLE}
             env: ${TAG_NAME}
         spec:
+          nodeSelector:
+            aporeto-enforcerd: 'true'
           containers:
             - image: ${NAME}
               imagePullPolicy: Always

--- a/fpo-web/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.yaml
+++ b/fpo-web/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.yaml
@@ -20,8 +20,12 @@ objects:
         Allow the frontend (web) to talk to the api pod.
       source:
         - - role=${ROLE}
+          - app: ${APP_NAME}
+          - env: ${TAG_NAME}
       destination:
         - - role=api
+          - app: ${APP_NAME}
+          - env: ${TAG_NAME}
 
   - kind: DeploymentConfig
     apiVersion: v1

--- a/fpo-web/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.yaml
+++ b/fpo-web/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.yaml
@@ -20,12 +20,12 @@ objects:
         Allow the frontend (web) to talk to the api pod.
       source:
         - - role=${ROLE}
-          - app: ${APP_NAME}
-          - env: ${TAG_NAME}
+          - app=${APP_NAME}
+          - env=${TAG_NAME}
       destination:
         - - role=api
-          - app: ${APP_NAME}
-          - env: ${TAG_NAME}
+          - app=${APP_NAME}
+          - env=${TAG_NAME}
 
   - kind: DeploymentConfig
     apiVersion: v1

--- a/openshift/TestConnections.txt
+++ b/openshift/TestConnections.txt
@@ -1,3 +1,7 @@
+# Uses the 'testConnection' script from https://github.com/BCDevOps/openshift-developer-tools
+# Example:
+# echo -e "angular-on-nginx\n django\n postgresql\n weasyprint\n schema-spy" | xargs -I {} testConnection -n jag-csb-jes-family-protection-order-dev -f TestConnections.txt -p {}
+
 google.com:80
 angular-on-nginx:8080
 django:8080


### PR DESCRIPTION
- Ensure the `app` and `env` labels are ANDed with the `role`.
- Ensure pods are deployed to nodes running an Aporeto enforcer.